### PR TITLE
fix: add default constructor to `Categoria`, add `toString`

### DIFF
--- a/src/main/java/tutorialjpa/model/Categoria.java
+++ b/src/main/java/tutorialjpa/model/Categoria.java
@@ -16,6 +16,8 @@ public class Categoria {
     private String nombre;
     private String descripcion;
 
+    public Categoria() {}
+
     public Categoria(String nombre, String descripcion) {
         this.nombre = nombre;
         this.descripcion = descripcion;
@@ -43,5 +45,14 @@ public class Categoria {
 
     public void setDescripcion(String descripcion) {
         this.descripcion = descripcion;
+    }
+
+    @Override
+    public String toString() {
+        return "Categoria{" +
+            "id=" + id +
+            ", nombre='" + nombre + '\'' +
+            ", descripcion='" + descripcion + '\'' +
+            '}';
     }
 }


### PR DESCRIPTION
Hibernate requires a default (empty) constructor to be able to instance data classes.
Added `toString()` to facilitate debugging.